### PR TITLE
Add Elasticsearch without external dependencies

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,5 @@
+class SearchController < ApplicationController
+  def index
+    @results = Elasticsearch.search(params[:query])
+  end
+end

--- a/app/jobs/elasticsearch_delete_job.rb
+++ b/app/jobs/elasticsearch_delete_job.rb
@@ -1,0 +1,5 @@
+class ElasticsearchDeleteJob < ApplicationJob
+  def perform(elasticsearch_id)
+    Elasticsearch.delete(elasticsearch_id)
+  end
+end

--- a/app/jobs/elasticsearch_index_job.rb
+++ b/app/jobs/elasticsearch_index_job.rb
@@ -1,0 +1,8 @@
+class ElasticsearchIndexJob < ApplicationJob
+  def perform(klass, id)
+    model = klass.constantize.find_by_id(id)
+    return unless model
+
+    Elasticsearch.index(model)
+  end
+end

--- a/app/models/concerns/elasticsearchable.rb
+++ b/app/models/concerns/elasticsearchable.rb
@@ -1,0 +1,30 @@
+module Elasticsearchable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit on: %i[create update], if: :should_index? do
+      ElasticsearchIndexJob.perform_later(self.class.name, id)
+    end
+
+    after_commit on: :destroy do
+      ElasticsearchDeleteJob.perform_later(elasticsearch_id)
+    end
+  end
+
+  # Override this method to control when the model should be indexed
+  def should_index?
+    true
+  end
+
+  def elasticsearch_id
+    "#{self.class.name}-#{id}"
+  end
+
+  def elasticsearch_title
+    title
+  end
+
+  def elasticsearch_content
+    raise NotImplementedError
+  end
+end

--- a/app/models/elasticsearch.rb
+++ b/app/models/elasticsearch.rb
@@ -1,0 +1,125 @@
+module Elasticsearch
+  INDEX = "searchables".freeze
+
+  def self.index(active_record_instance)
+    connection_pool.with do |client|
+      client.index(
+        INDEX,
+        active_record_instance.elasticsearch_id,
+        title: active_record_instance.elasticsearch_title,
+        content: active_record_instance.elasticsearch_content,
+        updated_at: active_record_instance.updated_at,
+        created_at: active_record_instance.created_at,
+      )
+    end
+  end
+
+  def self.delete(id)
+    connection_pool.with do |client|
+      client.delete(INDEX, id)
+    end
+  end
+
+  def self.search(query)
+    return [] if query.blank?
+
+    result = connection_pool.with do |client|
+      client.search(
+        INDEX,
+        _source: false,
+        stored_fields: %w[_id],
+        query: {
+          multi_match: {
+            query: query,
+            fields: %w[title^2 content],
+          },
+        },
+      )
+    end
+
+    ids = result.fetch("hits").fetch("hits").map { |hit| hit.fetch("_id") }
+
+    activerecord_class_and_ids =
+      ids.each_with_object({}) do |id, hash|
+        klass, id = id.split("-")
+        hash[klass] ||= []
+        hash[klass] << id
+      end
+
+    instances = activerecord_class_and_ids.flat_map do |klass, ids|
+      klass.constantize.where(id: ids)
+    end
+
+    instances.sort_by do |instance|
+      ids.index(instance.elasticsearch_id)
+    end
+  end
+
+  def self.connection_pool
+    @connection_pool ||= ConnectionPool.new(size: (ENV["RAILS_MAX_THREADS"] || 5).to_i, timeout: 5) do
+      Client.new
+    end
+  end
+
+  class Client
+    HttpError = Class.new(StandardError)
+
+    REQUEST_METHOD_TO_CLASS = {
+      get: Net::HTTP::Get,
+      post: Net::HTTP::Post,
+      put: Net::HTTP::Put,
+      delete: Net::HTTP::Delete,
+    }.freeze
+
+    def initialize
+      @url = ENV["ELASTICSEARCH_URL"] || "http://localhost:9200"
+    end
+
+    # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-index_.html#docs-index-api-request
+    def index(index, id, document)
+      request(:put, "#{index}/_doc/#{id}", document)
+    end
+
+    # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-delete.html#docs-delete-api-request
+    def delete(index, id)
+      request(:delete, "#{index}/_doc/#{id}")
+    end
+
+    # Search API reference:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-search.html#search-search
+    # Query body reference:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-search.html#search-search-api-request-body
+    def search(index, query)
+      request(:get, "#{index}/_search", query)
+    end
+
+    def request(method, path, params = nil)
+      uri = URI("#{@url}/#{path}")
+
+      request = REQUEST_METHOD_TO_CLASS.fetch(method).new(uri)
+      request.content_type = "application/json"
+      request.body = params&.to_json
+
+      Rails.logger.debug "[Elasticsearch/request] #{request.method} #{request.uri} #{request.body}" if Rails.logger.debug?
+
+      response = connection.request(request)
+
+      Rails.logger.debug "[Elasticsearch/response] #{response.code}, body: #{response.body}" if Rails.logger.debug?
+
+      raise HttpError, "status: #{response.code}, body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    end
+
+    private
+
+    def connection
+      @connection ||= begin
+        uri = URI.parse(@url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http
+      end
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,10 @@
 class Post < ApplicationRecord
+  include Elasticsearchable
+
   validates_presence_of :title
   validates_presence_of :body
+
+  def elasticsearch_content
+    body
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <nav style="font-size: 1.5rem;">
       <%= link_to "Posts", posts_path %>
       <%= link_to "Links", links_path %>
+      <%= link_to "Search", search_path %>
     </nav>
     <%= yield %>
   </body>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,16 @@
+<h1>Search</h1>
+
+<%= form_with url: search_path, method: :get do |form| %>
+  <%= form.label :query %>
+  <%= form.text_field :query, value: params[:query], autofocus: true %>
+  <%= form.submit "Search" %>
+<% end %>
+
+<% if @results.present? %>
+  <h2>Results</h2>
+  <ul>
+    <% @results.each do |result| %>
+      <li><%= link_to result.title, result %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   resources :links
   resources :posts
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  get "search" => "search#index", as: :search
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
## Why

The goal of the `rails-example` application is to serve as an example web application for learning how to deploy apps to the Reclaim the Stack platform. Currently it uses Postgres and Redis but since the platform also supports Elasticsearch we want the demo application to use this as well.

## What

Indexes the `Post` and `Link` models into a `searchable` Elasticsearch index to allow for doing full text search across both models. Each document in the index will use a `title` field with a high priority and a `content` field with lower priority (taken from `Post#body` and `Link#description` respectively).

This implementation uses `Net::HTTP` to interact with Elasticsearch, without involving any extra dependencies.

Feel free to compare with https://github.com/reclaim-the-stack/rails-example/pull/2 which is based on `elasticsearch-rails`.

### Lines of Code
Implementation: ~200 LOC
Dependencies: 0 LOC

### Time spent

Didn't keep track but approximately 2 hours.

### Issues
None

### Learnings
I learnt a few things about the Elasticsearch API which will come in handy when working with and debugging Elasticsearch in the future. I also learnt how to use `Net::HTTP` directly, which though not as streamlined as alternative HTTP clients, isn't the end of the world.